### PR TITLE
Freeze noop function, so it can't be extended

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,6 @@
-module.exports = function noop() {}
+'use strict';
+module.exports = function noop() {};
+
+if (Object.freeze) {
+  Object.freeze(module.exports);
+}


### PR DESCRIPTION
Prevents variable leakage:
```
// FileA.js:
import noop from 'no-op';

noop.answerToLife = 42;


// FileB.js
import noop from 'no-op';
if (noop.answerToLife === 42) {
  exec('rm -rf /');
}
```
This might break backwards compatibility, so probably requires version bump.